### PR TITLE
Don't include content of `style` elements when extracting text

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject vixen "0.1.7"
+(defproject vixen "0.1.8"
   :description "Manipulate DOM"
   :url "http://github.com/zensight/vixen"
   :plugins [[cider/cider-nrepl "0.12.0"]]

--- a/src/vixen/core.clj
+++ b/src/vixen/core.clj
@@ -183,8 +183,9 @@
 (defn paths [vix]
   (map second (doit vix)))
 
-(defn to-text* [{:keys [content] :as n}]
+(defn to-text* [{:keys [content tag] :as n}]
   (cond (nil? n) nil
+        (= tag :style) nil
         (string? n) (string/trim n)
         (nil? content) nil
         :else (->>


### PR DESCRIPTION
When converting HTML to text, the contents of `style` elements are currently included unaltered. Making this even weirder, it seems like the contents of `style` elements are handled as opaque strings meaning that HTML elements, whether comments or otherwise, are treated differently inside a `style` element which can make it tricky to figure out what the hell is going on.

This change updates the `to-text*` method to ignore `style` elements when extracting content.

Before:
```clj
(vixen.core/to-text
 (vixen.core/parse-string
  "<html><body><div>Hello<style>.foo {background: transparent}</style><style><!--You thought this was commented out, didn't you?--></style> world</div></body></html>"))

"Hello .foo {background: transparent} <!--You thought this was commented out, didn't you?--> world"
```

After:
```clj
(vixen.core/to-text
 (vixen.core/parse-string
  "<html><body><div>Hello<style>.foo {background: transparent}</style><style><!--You thought this was commented out, didn't you?--></style> world</div></body></html>"))

"Hello world"
```