### PR TITLE
In search, use `into` instead of `concat` to avoid concat-aclysm

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject vixen "0.1.8"
+(defproject vixen "0.1.9"
   :description "Manipulate DOM"
   :url "http://github.com/zensight/vixen"
   :plugins [[cider/cider-nrepl "0.12.0"]]

--- a/src/vixen/core.clj
+++ b/src/vixen/core.clj
@@ -144,13 +144,14 @@
            [[n p] & others] [[node path]]]
       (if n
         (let [newly (selector n p vix)]
-          (recur (if (empty? newly) found (concat found newly))
+          ;; Prefer `into` over `concat` below to support arbitrary stack depth and result count
+          (recur (if (empty? newly) found (into found newly))
                  (if (empty? (:content n))
                              others
-                             (concat others
-                                     (map-indexed (fn [i child]
-                                                    [child (conj p i)])
-                                                  (:content n))))))
+                             (into (vec others)
+                                   (map-indexed (fn [i child]
+                                                  [child (conj p i)])
+                                                (:content n))))))
         found))))
 
 (defn path->selector [path]


### PR DESCRIPTION
Hitting an issue where the use of `concat` is resulting in a StackOverflow when searching a particularly horrible email. More specifically, the use of `concat` to build/maintain the stack of pending nodes is problematic. I'm not sure it's a problem when accumulating the list of found nodes, but I don't see why not.

This blog post does a nice job of explaining the issue: https://stuartsierra.com/2015/04/26/clojure-donts-concat

I've tried to put some thought into the ordering semantics since `concat` always returns lists and `into` always returns the type of the first argument. I think the ordering of `found` and the working stack is preserved, but it's worth double checking.